### PR TITLE
Use travis' new build workers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+sudo: false
 python:
   - 2.7
   - 3.3


### PR DESCRIPTION
They boot faster and there's no reason why we shouldn't use them since we don't need sudo access.
