### PR TITLE
Raise ImproperlyConfigured

### DIFF
--- a/stream_django/__init__.py
+++ b/stream_django/__init__.py
@@ -1,1 +1,3 @@
 from stream_django.feed_manager import feed_manager
+default_app_config = 'stream_django.apps.StreamDjangoConfig'
+

--- a/stream_django/apps/__init__.py
+++ b/stream_django/apps/__init__.py
@@ -1,0 +1,11 @@
+from django.apps import AppConfig
+from django.core.exceptions import ImproperlyConfigured
+from stream_django.conf import is_valid_config
+
+class StreamDjangoConfig(AppConfig):
+    name = 'stream_django'
+    verbose_name = "Stream Django"
+
+    def ready(self):
+      if not is_valid_config():
+        raise ImproperlyConfigured('Stream credentials are not set in your settings')

--- a/stream_django/client.py
+++ b/stream_django/client.py
@@ -1,13 +1,19 @@
 from stream_django import conf
 import os
 import stream
+from stream_django.conf import DJANGO_MAJOR_VERSION
 from django.core.exceptions import ImproperlyConfigured
 
-if conf.API_KEY and conf.API_SECRET:
-    stream_client = stream.connect(
-        conf.API_KEY, conf.API_SECRET, location=conf.LOCATION, timeout=conf.TIMEOUT)
-else:
-    stream_client = stream.connect()
+def init_client(mayRaise=False):
+  if conf.API_KEY and conf.API_SECRET:
+      stream_client = stream.connect(
+          conf.API_KEY, conf.API_SECRET, location=conf.LOCATION, timeout=conf.TIMEOUT)
+  elif os.environ.get('STREAM_URL') is not None:
+      stream_client = stream.connect()
+  else:
+      stream_client = None
+      if mayRaise:
+        raise ImproperlyConfigured('Stream credentials are not set in your settings')
 
-if os.environ.get('STREAM_URL') is None and not(conf.API_KEY and conf.API_SECRET):
-    raise ImproperlyConfigured('Stream credentials are not set in your settings')
+stream_client = init_client(mayRaise=DJANGO_MAJOR_VERSION<1.7)
+

--- a/stream_django/client.py
+++ b/stream_django/client.py
@@ -4,16 +4,13 @@ import stream
 from stream_django.conf import DJANGO_MAJOR_VERSION
 from django.core.exceptions import ImproperlyConfigured
 
-def init_client(mayRaise=False):
+def init_client(raise_config_error=False):
   if conf.API_KEY and conf.API_SECRET:
-      stream_client = stream.connect(
-          conf.API_KEY, conf.API_SECRET, location=conf.LOCATION, timeout=conf.TIMEOUT)
+      return stream.connect(conf.API_KEY, conf.API_SECRET, location=conf.LOCATION, timeout=conf.TIMEOUT)
   elif os.environ.get('STREAM_URL') is not None:
-      stream_client = stream.connect()
-  else:
-      stream_client = None
-      if mayRaise:
-        raise ImproperlyConfigured('Stream credentials are not set in your settings')
+      return stream.connect()
+  elif raise_config_error:
+      raise ImproperlyConfigured('Stream credentials are not set in your settings')
 
-stream_client = init_client(mayRaise=DJANGO_MAJOR_VERSION<1.7)
+stream_client = init_client(raise_config_error=DJANGO_MAJOR_VERSION<1.7)
 

--- a/stream_django/conf.py
+++ b/stream_django/conf.py
@@ -1,4 +1,5 @@
 import django
+import os
 from django.conf import settings
 
 API_KEY = getattr(settings, 'STREAM_API_KEY', None)
@@ -19,3 +20,6 @@ NOTIFICATION_FEED = getattr(settings, 'STREAM_PERSONAL_FEED', 'notification')
 DISABLE_MODEL_TRACKING = getattr(settings, 'STREAM_DISABLE_MODEL_TRACKING', False)
 
 DJANGO_MAJOR_VERSION = django.VERSION[0] + (0.1*django.VERSION[1])
+
+def is_valid_config():
+  return (API_KEY and API_SECRET) or os.environ.get('STREAM_URL')


### PR DESCRIPTION
Raise error when STREAM_API_KEY or STREAM_API_SECRET are not set. #27 