### PR TITLE
Remove type cast to integer

### DIFF
--- a/stream_django/enrich.py
+++ b/stream_django/enrich.py
@@ -118,7 +118,7 @@ class Enrich(object):
             if not self.is_ref(activity, field):
                 continue
             f_ct, f_id = activity[field].split(':')
-            instance = objects[f_ct].get(int(f_id))
+            instance = objects[f_ct].get(f_id)
             if instance is None:
                 activity.track_not_enriched_field(field, activity[field])
             else:


### PR DESCRIPTION
Identifiers are being type casted into integers. This will cause problems for people that are using UUID's.