### PR TITLE
Django 1 11 compatibility

### DIFF
--- a/stream_django/templatetags/activity_tags.py
+++ b/stream_django/templatetags/activity_tags.py
@@ -43,7 +43,7 @@ def render_activity(context, activity, template_prefix='', missing_data_policy=L
     tmpl = loader.get_template(template_name)
     context['activity'] = activity
 
-    if django.get_version() >= 1.11:
+    if django.get_version() < 1.11:
         context = Context(context)
 
     return tmpl.render(context)

--- a/stream_django/templatetags/activity_tags.py
+++ b/stream_django/templatetags/activity_tags.py
@@ -1,5 +1,5 @@
 from django import template
-from django.template import Context, loader
+from django.template import loader
 from stream_django.exceptions import MissingDataException
 import logging
 
@@ -41,7 +41,6 @@ def render_activity(context, activity, template_prefix='', missing_data_policy=L
 
     tmpl = loader.get_template(template_name)
     context['activity'] = activity
-    context = Context(context)
     return tmpl.render(context)
 
 

--- a/stream_django/templatetags/activity_tags.py
+++ b/stream_django/templatetags/activity_tags.py
@@ -1,5 +1,6 @@
+import django
 from django import template
-from django.template import loader
+from django.template import Context, loader
 from stream_django.exceptions import MissingDataException
 import logging
 
@@ -41,6 +42,10 @@ def render_activity(context, activity, template_prefix='', missing_data_policy=L
 
     tmpl = loader.get_template(template_name)
     context['activity'] = activity
+
+    if django.get_version() >= 1.11:
+        context = Context(context)
+
     return tmpl.render(context)
 
 


### PR DESCRIPTION
When using render_activity and passing a context, Django 1.11 raises the error:
`context must be a dict rather than Context.`

Check if the current version is less than 1.11, if so, use the class Context, otherwise pass the normal dictionary context to loader.get_template(template_name).render(context).