### PR TITLE
Fix Django 1.11 compatibility issue: https://docs.djangoproject.com/e…

### DIFF
--- a/stream_django/templatetags/activity_tags.py
+++ b/stream_django/templatetags/activity_tags.py
@@ -43,8 +43,10 @@ def render_activity(context, activity, template_prefix='', missing_data_policy=L
     tmpl = loader.get_template(template_name)
     context['activity'] = activity
 
-    if django.get_version() < 1.11:
+    if float(django.get_version()) < 1.11:
         context = Context(context)
+    elif isinstance(context, Context):
+        context = context.flatten()
 
     return tmpl.render(context)
 


### PR DESCRIPTION
…n/1.11/releases/1.11/#django-template-backends-django-template-render-prohibits-non-dict-context

1. django.get_version() returns string, so it has to be parsed to float to be able to compare to 1.11
2.  Due to changes in Django 1.11: https://docs.djangoproject.com/en/1.11/releases/1.11/#django-template-backends-django-template-render-prohibits-non-dict-context, RequestContext, which comes to this templatetag has to be "reverted back" to context of type `dict` in order to be able to render it again.
