### PR TITLE
Add hook for subclass to handle enriching

### DIFF
--- a/stream_django/enrich.py
+++ b/stream_django/enrich.py
@@ -125,4 +125,7 @@ class Enrich(object):
             if instance is None:
                 activity.track_not_enriched_field(field, activity[field])
             else:
-                activity[field] = instance
+                activity[field] = self.enrich_instance(instance)
+
+    def enrich_instance(self, instance):
+        return instance


### PR DESCRIPTION
With this change it is trivial to subclass Enrich and provide an implementation of `enrich_instance` which might serialize the instance so the final results can be dropped into a `rest_framework.Response`.