### PR TITLE
Support django 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,8 @@ notifications:
 install:
   - travis_retry pip install pep8==1.7.0
   - travis_retry pip install python-coveralls
-  - travis_retry pip install -e .
   - travis_retry pip install $DJANGO --upgrade
+  - travis_retry pip install -e .
 script:
   - coverage run --source=stream_django setup.py test
 after_script:

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Below shows an example how to set things up if your user field is called author.
 ```python
 class Tweet(models.Model, Activity):
     created_at = models.DateTimeField(auto_now_add=True)
-    author = models.ForeignKey(settings.AUTH_USER_MODEL)
+    author = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
 
     @property
     def activity_actor_attr(self):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open(os.path.join(os.path.dirname(__file__), 'README.md')) as readme:
     README = readme.read()
 
 requirements = [
-    'django>=1.5,<2.0',
+    'django>=1.5,<2.1.0',
     'stream-python>=2.8.0',
     'pytz'
 ]

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(os.path.dirname(__file__), 'README.md')) as readme:
 
 requirements = [
     'django>=1.5,<2.1.0',
-    'stream-python>=2.8.0',
+    'stream-python>=2.8.1',
     'pytz'
 ]
 

--- a/stream_django/tests/test_app/migrations/0001_initial.py
+++ b/stream_django/tests/test_app/migrations/0001_initial.py
@@ -18,7 +18,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('created_at', models.DateTimeField(auto_now_add=True)),
-                ('author', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+                ('author', models.ForeignKey(to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE)),
             ],
             options={
             },

--- a/stream_django/tests/test_app/models.py
+++ b/stream_django/tests/test_app/models.py
@@ -4,7 +4,7 @@ from stream_django.activity import Activity
 
 
 class Pin(models.Model, Activity):
-    author = models.ForeignKey(settings.AUTH_USER_MODEL)
+    author = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     created_at = models.DateTimeField(auto_now_add=True)
 
     @property


### PR DESCRIPTION
Needed to re-order the travis installation steps so it would pick up the Django version specific to the build matrix and not the highest Django version supported by the setup.py dependency.

The previous ordering seems a little strange to me so perhaps I'm overlooking something.

The previous [travis build ](https://travis-ci.org/GetStream/stream-django/jobs/319802442) on the branch shows we're the problem manifests.

Closes #72 #71 #70 #69.