### PR TITLE
Allow alternatives to pk for object lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ enriched_activities = enricher.enrich_activities(activities)
 
 #### Change how models are retrieved
 
-The enrich class that comes with the packages tries to minimise the amount of database queries. The models are grouped by their class and then retrieved with a pk__in query. You can implement a different approach to retrieve the instances of a model subclassing the ```stream_django.enrich.Enrich``` class.
+The enrich class that comes with the packages tries to minimise the amount of database queries. The models are grouped by their class and then retrieved with a bulk query. You can implement a different approach to retrieve the instances of a model subclassing the ```stream_django.enrich.Enrich``` class.
 
 To change the retrieval for every model you should override the ```fetch_model_instances``` method; in alternative you can change how certain models' are retrieved by implementing the hook function ```fetch_<model_name>_instances```
 
@@ -326,10 +326,10 @@ class MyEnrich(Enrich):
     Overwrites how model instances are fetched from the database
     '''
 
-    def fetch_model_instances(self, modelClass, pks):
+    def fetch_model_instances(self, modelClass, lookup_values):
         '''
-        returns a dict {id:modelInstance} with instances of model modelClass
-        and pk in pks
+        returns a dict {lookup_value:modelInstance} with instances of model modelClass
+        and lookup_value in lookup_values
         '''
         ...
 
@@ -338,7 +338,7 @@ class AnotherEnrich(Enrich):
     Overwrites how Likes instances are fetched from the database
     '''
 
-    def fetch_like_instances(self, pks):
+    def fetch_like_instances(self, lookup_values):
         return {l.id: l for l in Like.objects.cached_likes(ids)}
 
 ```

--- a/stream_django/enrich.py
+++ b/stream_django/enrich.py
@@ -91,18 +91,23 @@ class Enrich(object):
             model_references[f_ct].append(f_id)
         return model_references
 
-    def fetch_model_instances(self, modelClass, pks):
+    def fetch_model_instances(self, modelClass, lookup_values):
         '''
-        returns a dict {id:modelInstance} with instances of model modelClass
-        and pk in pks
+        returns a dict {<lookup_value>:modelInstance} with instances of model modelClass
+        and lookup_value in lookup_values  (i.e., {1:<obj_1>} or {<uuid>:<obj_2>})
         '''
+        try:
+            lookup_field_name = modelClass.activity_lookup_field()
+        except AttributeError:
+            lookup_field_name = 'pk'
+        
         hook_function_name = 'fetch_%s_instances' % (modelClass._meta.object_name.lower(), )
         if hasattr(self, hook_function_name):
-            return getattr(self, hook_function_name)(pks)
+            return getattr(self, hook_function_name)(lookup_values)
         qs = modelClass.objects
         if hasattr(modelClass, 'activity_related_models') and modelClass.activity_related_models() is not None:
             qs = qs.select_related(*modelClass.activity_related_models())
-        return qs.in_bulk(pks)
+        return qs.in_bulk(lookup_values, field_name=lookup_field_name)
 
     def _fetch_objects(self, references):
         objects = defaultdict(list)
@@ -119,8 +124,14 @@ class Enrich(object):
                 continue
             f_ct, f_id = activity[field].split(':')
             model = get_model(*f_ct.split('.'))
-            f_id = model._meta.pk.to_python(f_id)
-
+            
+            try:
+                lookup_field_name = model.activity_lookup_field()
+                lookup_field = model._meta.get_field(lookup_field_name)
+                f_id = lookup_field.to_python(f_id)
+            except AttributeError:
+                f_id = model._meta.pk.to_python(f_id)
+                
             instance = objects[f_ct].get(f_id)
             if instance is None:
                 activity.track_not_enriched_field(field, activity[field])


### PR DESCRIPTION
Hi you all. First - thanks for providing the django client project.

Some Django projects use both an integer id/pk along with a spearate uuid field where only the uuid is exposed externally to clients. This PR adds DRF-like field lookup name functionality so a user could choose to have activities use that identifier rather than pk.

Note that this is a separate problem than the UUID issue here: https://github.com/GetStream/stream-django/pull/55/files

I'm using this on a personal project but providing in case you want to consider (or point others to a solution in case it comes up in the future).