### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ Disable automatic tracking of Activity models. Default ```False```
 
 ### Temporarily disabling the signals
 
-Model syncronization is disabled during schema/data migrations runs, syncdb and fixture loading (and during django test runs).
+Model synchronization is disabled during schema/data migrations runs, syncdb and fixture loading (and during django test runs).
 You can completely disable feed publishing via the ```STREAM_DISABLE_MODEL_TRACKING``` django setting.
 
 

--- a/stream_django/activity.py
+++ b/stream_django/activity.py
@@ -36,7 +36,7 @@ class Activity(object):
     def activity_author_feed(self):
         '''
         The name of the feed where the activity will be stored; this is normally
-        used by the manager class to determine if the activity should be stored elsewehere than
+        used by the manager class to determine if the activity should be stored elsewhere than
         settings.USER_FEED
         '''
         pass


### PR DESCRIPTION
There are small typos in:
- README.md
- stream_django/activity.py

Fixes:
- Should read `synchronization` rather than `syncronization`.
- Should read `elsewhere` rather than `elsewehere`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md