### PR TITLE
Fix version checking for Django 3.2

### DIFF
--- a/stream_django/__init__.py
+++ b/stream_django/__init__.py
@@ -1,7 +1,8 @@
 import django
 from stream_django.feed_manager import feed_manager  # noqa
 
-major, minor, _ = (int(i) for i in django.__version__.split('.'))
+version_list = [int(i) for i in django.__version__.split('.')]
+major, minor = version_list[0], version_list[1]
 
 if major < 3 or (major == 3 and minor < 2):
     # deprecated as of Django 3.2


### PR DESCRIPTION
This fix prevents ValueError: not enough values to unpack (expected 3, got 2)